### PR TITLE
fix(export): filter out internal metadata keys from plaintext exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-23
+
 ### Added
 
 - **Cryptographic Audit Log**: Every state-changing CLI operation is now recorded in a cryptographically
@@ -23,6 +25,13 @@ All notable changes to this project will be documented in this file.
 
 - Standardized all internal imports to use the `node:` prefix for better cross-runtime compatibility.
 - Repositioned as a "secret management layer" focused on governance and trust.
+- Migrated test framework compilation from `ts-jest` to `@swc/jest`, reducing test suite execution times by
+  over 45%.
+
+### Fixed
+
+- Filtered out internal metadata keys (like `_AUDIT` and `_RECIPIENT`) from `secenvs export` output.
+- Resolved various flaky test environments spanning raw binary invocations and ANSI shell coloring edge cases.
 
 ## [0.1.5] - 2026-02-16
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -389,7 +389,7 @@ async function cmdExport(force: boolean = false) {
    const parsed = parseEnvFile(envPath)
 
    for (const line of parsed.lines) {
-      if (line.key) {
+      if (line.key && !line.key.startsWith("_")) {
          let value: string
          if (line.encrypted) {
             const decrypted = await decryptValue(identity, line.value.slice(ENCRYPTED_PREFIX.length))


### PR DESCRIPTION
## What this PR does
Fixes a bug where `secenvs export` attempts to validate, decrypt, and export internal metadata keys like `_AUDIT` and `_RECIPIENT`, leading to a validation crash. With this fix, any key starting with an underscore `_` is completely ignored during plaintext exports.

Also properly bumps the `CHANGELOG.md` structure mapping out all these new changes into the forthcoming `0.2.0` release section.