### PR TITLE
docs: Add Code of Conduct & Update Project Name

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# secenvs Code of Conduct
+
+## The "Breeze" Philosophy
+
+**secenvs** is built on the philosophy of "security without the ceremony." We value lightweight, fast, and intensely focused engineering. This community is designed for solo developers and small teams who want to build great things without tripping over red tape.
+
+Our code of conduct reflects this philosophy. We do not have a massive, corporate rulebook or a multi-layered moderation committee. We have a few simple, common-sense rules.
+
+## The Rules
+
+1. **Keep it Technical, Keep it Focused**
+   We are here to build the best, lowest-friction secret management tool in the world. Discussions in issues, PRs, and community spaces should remain tightly focused on technical implementation, design, and user experience. 
+
+2. **Be Pragmatic and Direct**
+   We value brutal honesty about code, but zero tolerance for personal attacks. Critique the implementation, not the person. If code is bad, say *why* it's bad technically. Don't waste time dancing around the issue, but don't use directness as an excuse to be mean.
+
+3. **Assume Good Intent**
+   Developers come from all backgrounds and skill levels. If someone submits a buggy PR or asks a question that seems obvious to you, assume they are acting in good faith. Help them out or move on.
+
+4. **Don't Be a Jerk**
+   No harassment, discrimination, trolling, or abusive language of any kind. We do not tolerate behavior that makes others feel unwelcome based on who they are.
+
+## Enforcement
+
+There is no complex enforcement ladder. If you are disruptive, hostile, or actively degrade the quality of the project or the community, the maintainers will warn you. If the behavior continues—or is egregious enough on the first offense—you will be blocked from the repository.
+
+**Maintainers have the final say**. We reserve the right to close PRs, lock issues, or block users to keep the project moving fast, keeping the community healthy, and protecting the maintainers' bandwidth.
+
+*This project favors shipping and doing the right thing over endless debate.*

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,8 +1,8 @@
-# secenv: The Designer's Brief
+# secenvs: The Designer's Brief
 
 ## 1. Introduction & The Name
 
-**secenv** (Secure Environment) is the "Breeze" of secret management. It is a CLI tool and TypeScript SDK that
+**secenvs** (Secure Environment) is the "Breeze" of secret management. It is a CLI tool and TypeScript SDK that
 allows developers to encrypt their environment variables locally, making it 100% safe to commit sensitive
 secrets (like API keys and database URLs) directly into Git.
 
@@ -28,12 +28,12 @@ The core vision is simple: **Security without the ceremony. Git-safe secrets wit
 
 - **Identity over Passwords:** You don't manage passwords per project. You manage _Trust_ using your local
   identity (like an SSH key).
-- **Single Source of Truth:** No extra config files (`secenv.yaml`). Your `.env.enc` file is both your schema
+- **Single Source of Truth:** No extra config files (`secenvs.yaml`). Your `.env.enc` file is both your schema
   and your storage.
 - **Zero Wrapper Dependency:** Instead of complex start commands, TypeScript apps just
-  `import { env } from "secenv"`. It decrypts exactly what it needs, exactly when it needs it.
+  `import { env } from "secenvs"`. It decrypts exactly what it needs, exactly when it needs it.
 
-**The Positioning Statement:** _"SOPS is for DevOps teams. secenv is for solo TypeScript developers who want
+**The Positioning Statement:** _"SOPS is for DevOps teams. secenvs is for solo TypeScript developers who want
 Git-safe secrets without the ceremony."_
 
 ## 4. The Impact & The "Unfair Advantage"
@@ -59,11 +59,11 @@ on GitHub. No more spending an hour setting up a new project's `.env` file just 
 
 ## 6. Key Features to Highlight visually
 
-- **Zero Wrapper DX:** Show how simple it is: `import { env } from "secenv"`.
+- **Zero Wrapper DX:** Show how simple it is: `import { env } from "secenvs"`.
 - **Selective Encryption:** Show a file where non-sensitive configs (like `PORT=3000`) stay readable
   plaintext, while sensitive API keys are encrypted on the same file.
 - **Risk-Free Git Commits:** Illustrate pushing your `.env.enc` to public repositories with zero fear.
-- **The "Doctor":** We have a built-in `secenv doctor` command that acts as a health check to make sure the
+- **The "Doctor":** We have a built-in `secenvs doctor` command that acts as a health check to make sure the
   developer is set up correctly.
 
 ## 7. The Design Challenge
@@ -71,4 +71,4 @@ on GitHub. No more spending an hour setting up a new project's `.env` file just 
 We are asking people to change an established, deeply ingrained workflow (the ubiquitous `.env` file). The
 landing page needs to look incredibly premium and make adoption feel absolutely effortless. The design must
 visually contrast the "managerial hell" of enterprise secret tools against the sleek, instant gratification of
-`secenv`.
+`secenvs`.


### PR DESCRIPTION
## Description

- Added a lightweight, pragmatic `CODE_OF_CONDUCT.md` aligned with the project's 'Breeze' philosophy (focused on minimizing managerial layers for solo devs).
- Replaced outdated references to `secenv` with the current project name `secenvs` in `docs/VISION.md` (and internal `.dev` docs which are gitignored but updated locally).
